### PR TITLE
Implement supply retrieval by id

### DIFF
--- a/dao/supply_dao.py
+++ b/dao/supply_dao.py
@@ -45,3 +45,17 @@ class SupplyDAO:
                 storekeeper_id=row[4]
             ) for row in rows
         ]
+
+    def find_by_id(self, supply_id: int) -> Supply | None:
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM supplies WHERE id = ?", (supply_id,))
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return Supply(
+            id=row[0],
+            supply_date=datetime.fromisoformat(row[1]).date(),
+            supplier_id=row[2],
+            warehouse_id=row[3],
+            storekeeper_id=row[4]
+        )

--- a/tests/dao/test_supply_dao.py
+++ b/tests/dao/test_supply_dao.py
@@ -26,3 +26,14 @@ def test_insert_and_find_all(dao):
     all_s = dao.find_all()
     assert any(x.id == s_id for x in all_s)
     assert all_s[0].supply_date == date(2025, 5, 30)
+
+
+def test_find_by_id(dao):
+    s = Supply(supply_date=date(2024, 1, 1), supplier_id=1, warehouse_id=1, storekeeper_id=1)
+    s_id = dao.insert(s)
+    found = dao.find_by_id(s_id)
+    assert found is not None
+    assert found.supply_date == date(2024, 1, 1)
+    assert found.supplier_id == 1
+    assert found.warehouse_id == 1
+    assert found.storekeeper_id == 1


### PR DESCRIPTION
## Summary
- extend `SupplyDAO` with `find_by_id`
- verify retrieval via new unit test

## Testing
- `xvfb-run -a pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452824d2ec8328b50597d5f9985105