### PR TITLE
Implement role-based tab hiding via login window

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
-from ui.main_window import MainWindow
+from ui.login_window import LoginWindow
 
 
 if __name__ == "__main__":
-    app = MainWindow()
-    app.mainloop()
+    LoginWindow().mainloop()

--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -1,0 +1,40 @@
+import tkinter as tk
+from tkinter import ttk
+
+from ui.main_window import MainWindow
+
+class LoginWindow(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Вхід")
+        self.geometry("300x150")
+        self.resizable(False, False)
+
+        ttk.Label(self, text="Оберіть роль:").pack(pady=10)
+        self.role_cb = ttk.Combobox(
+            self,
+            state="readonly",
+            values=["Керівник", "Менеджер", "Склад"],
+        )
+        self.role_cb.pack(pady=5)
+        ttk.Button(self, text="Увійти", command=self._login).pack(pady=10)
+
+    def _login(self):
+        role = self.role_cb.get()
+        if not role:
+            return
+        self.destroy()
+        main = MainWindow()
+        nb = main.nb
+        if role == "Керівник":
+            nb.hide(nb.index("Постачальники"))
+            nb.hide(nb.index("Замовлення"))
+            nb.hide(nb.index("Склад"))
+        elif role == "Менеджер":
+            nb.hide(nb.index("Звіти"))
+            nb.hide(nb.index("Склад"))
+        elif role == "Склад":
+            nb.hide(nb.index("Звіти"))
+            nb.hide(nb.index("Постачальники"))
+            nb.hide(nb.index("Замовлення"))
+        main.mainloop()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -18,23 +18,23 @@ class MainWindow(tk.Tk):
         self.rowconfigure(0, weight=1)
         self.columnconfigure(0, weight=1)
 
-        notebook = ttk.Notebook(self)
-        notebook.grid(row=0, column=0, sticky="nsew")
-        notebook.rowconfigure(0, weight=1)
-        notebook.columnconfigure(0, weight=1)
+        self.nb = ttk.Notebook(self)
+        self.nb.grid(row=0, column=0, sticky="nsew")
+        self.nb.rowconfigure(0, weight=1)
+        self.nb.columnconfigure(0, weight=1)
 
         tabs = [
-            ("Звіти", ReportsTab(notebook)),
-            ("Постачальники", SuppliersTab(notebook)),
-            ("Замовлення", OrdersTab(notebook)),
-            ("Склади", WarehouseTab(notebook)),
-            ("Комплектуючі", ComponentTab(notebook)),
-            ("Комірники", StorekeeperTab(notebook)),
-            ("Поставки", SupplyTab(notebook)),
+            ("Звіти", ReportsTab(self.nb)),
+            ("Постачальники", SuppliersTab(self.nb)),
+            ("Замовлення", OrdersTab(self.nb)),
+            ("Склади", WarehouseTab(self.nb)),
+            ("Комплектуючі", ComponentTab(self.nb)),
+            ("Комірники", StorekeeperTab(self.nb)),
+            ("Поставки", SupplyTab(self.nb)),
         ]
 
         for text, tab in tabs:
-            notebook.add(tab, text=text)
+            self.nb.add(tab, text=text)
 
 
 


### PR DESCRIPTION
## Summary
- expose notebook of `MainWindow` as `self.nb`
- create `LoginWindow` with role selection
- integrate login window in `main.py`

## Testing
- `pytest -q` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6845a7a9eb1483289a07df7e35c9ad8c