### PR TITLE
Add base controllers for reports and orders

### DIFF
--- a/controllers/orders_controller.py
+++ b/controllers/orders_controller.py
@@ -1,0 +1,20 @@
+from services.order_service import OrderService
+from services.contract_service import ContractService
+from ui.orders_tab import OrdersTab
+
+
+class OrdersController:
+    def __init__(self, view: OrdersTab, service: OrderService, contract_service: ContractService):
+        self.view = view
+        self.service = service
+        self.contract_service = contract_service
+        view.set_controller(self)
+
+    def create_order(self):
+        dto = {}
+        self.service.create(dto)
+        self.view.refresh(self.service.list_all())
+
+    def check_contract(self):
+        self.contract_service.verify()
+        self.view.refresh(self.service.list_all())

--- a/controllers/reports_controller.py
+++ b/controllers/reports_controller.py
@@ -1,0 +1,19 @@
+from services.report_service import ReportService
+from services.history_service import HistoryService
+from ui.reports_tab import ReportsTab
+from ui.supply_history_window import SupplyHistoryWindow
+
+
+class ReportsController:
+    def __init__(self, view: ReportsTab, service: ReportService, history_service: HistoryService):
+        self.view = view
+        self.service = service
+        self.history_service = history_service
+        view.set_controller(self)
+
+    def generate_report(self):
+        self.service.create_report()
+
+    def show_supply_history(self):
+        data = self.history_service.list()
+        SupplyHistoryWindow(data)


### PR DESCRIPTION
## Summary
- implement `ReportsController` with report generation and supply history view
- add `OrdersController` for order creation and contract checking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a7862a708328883766612e4c4a34