### PR TITLE
Update order management integration

### DIFF
--- a/controllers/orders_controller.py
+++ b/controllers/orders_controller.py
@@ -1,11 +1,10 @@
-class OrderController:
-    def __init__(self, service=None, view=None, contract_service=None):
-        self.service = service
+class OrdersController:
+    def __init__(self, view=None, service=None, contract_service=None):
         self.view = view
+        self.service = service
         self.contract_service = contract_service
 
     def create_order(self):
-        """Create a new order."""
         if not self.service:
             return
         dto = {}
@@ -16,7 +15,6 @@ class OrderController:
             self.view.refresh(self.service.list_all())
 
     def check_contract(self):
-        """Check supplier contract for the current order."""
         if self.contract_service:
             self.contract_service.validate_contract(1)
         if self.view and hasattr(self.view, "refresh"):

--- a/dao/order_dao.py
+++ b/dao/order_dao.py
@@ -1,0 +1,51 @@
+import sqlite3
+
+
+class OrderDAO:
+    """Simple SQLite-based DAO for orders."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+        self._ensure_table()
+
+    def _ensure_table(self):
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS orders (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                order_id TEXT,
+                supplier TEXT,
+                status TEXT,
+                date TEXT
+            )
+            """
+        )
+        self.conn.commit()
+
+    def insert(self, dto: dict) -> int:
+        cur = self.conn.execute(
+            "INSERT INTO orders (order_id, supplier, status, date) VALUES (?, ?, ?, ?)",
+            (
+                dto.get("order_id"),
+                dto.get("supplier"),
+                dto.get("status"),
+                dto.get("date"),
+            ),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
+    def find_all(self) -> list[dict]:
+        cur = self.conn.execute(
+            "SELECT id, order_id, supplier, status, date FROM orders"
+        )
+        return [
+            {
+                "id": row[0],
+                "order_id": row[1],
+                "supplier": row[2],
+                "status": row[3],
+                "date": row[4],
+            }
+            for row in cur.fetchall()
+        ]

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from db.database import get_connection
 from ui.main_window import MainWindow
 from controllers.supplier_controller import SupplierController
 from controllers.component_controller import ComponentController
-from controllers.order_controller import OrderController
+from controllers.orders_controller import OrdersController
 from controllers.report_controller import ReportController
 from controllers.supply_controller import SupplyController
 from services.supplier_service import SupplierService
@@ -21,6 +21,7 @@ from dao.warehouse_dao import WarehouseDAO
 from dao.storekeeper_dao import StorekeeperDAO
 from dao.supply_dao import SupplyDAO
 from dao.supply_record_dao import SupplyRecordDAO
+from dao.order_dao import OrderDAO
 from dao.contract_dao import ContractDAO
 from dao.history_dao import HistoryDAO
 
@@ -66,9 +67,9 @@ def main():
     )
     suppliers_tab.set_controller(supplier_ctrl)
 
-    orders_ctrl = OrderController(
+    orders_ctrl = OrdersController(
         orders_tab,
-        OrderService(),
+        OrderService(OrderDAO(conn)),
         ContractService(ContractDAO()),
     )
     orders_tab.set_controller(orders_ctrl)

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -1,18 +1,17 @@
-class OrderService:
-    """Simple in-memory order management service."""
+from dao.order_dao import OrderDAO
 
-    def __init__(self):
-        self._orders: list[dict] = []
-        self._next_id = 1
+
+class OrderService:
+    """Facade for order management via DAO."""
+
+    def __init__(self, order_dao: OrderDAO):
+        self.order_dao = order_dao
 
     def create(self, dto: dict) -> dict:
-        """Create a new order from ``dto`` and return stored representation."""
+        order_id = self.order_dao.insert(dto)
         order = dict(dto)
-        order["id"] = self._next_id
-        self._next_id += 1
-        self._orders.append(order)
+        order["id"] = order_id
         return order
 
     def list_all(self) -> list[dict]:
-        """Return list of all created orders."""
-        return list(self._orders)
+        return self.order_dao.find_all()

--- a/tests/test_usecase_mapping.py
+++ b/tests/test_usecase_mapping.py
@@ -3,7 +3,7 @@ from controllers.report_controller import ReportController
 from controllers.supplier_controller import SupplierController
 from controllers.component_controller import ComponentController
 from controllers.supply_controller import SupplyController
-from controllers.order_controller import OrderController
+from controllers.orders_controller import OrdersController
 
 
 def test_report_controller_methods():
@@ -28,5 +28,5 @@ def test_supply_controller_methods():
 
 
 def test_order_controller_methods():
-    assert hasattr(OrderController, "create_order")
-    assert hasattr(OrderController, "check_contract")
+    assert hasattr(OrdersController, "create_order")
+    assert hasattr(OrdersController, "check_contract")


### PR DESCRIPTION
## Summary
- add DAO-backed `OrdersController`
- refactor `OrderService` to use new `OrderDAO`
- wire up DAO-based controller in `main.py`
- adjust tests for renamed controller

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f70feea88328a9cdffd61e6e2d69