### PR TITLE
Implement new service/controller APIs

### DIFF
--- a/controllers/order_controller.py
+++ b/controllers/order_controller.py
@@ -5,19 +5,21 @@ class OrderController:
         self.contract_service = contract_service
 
     def create_order(self):
-        """Create a new order."""
-        if not self.service:
+        """Create an order from the view form."""
+        if not self.view or not self.service:
             return
         dto = {}
-        if self.view and hasattr(self.view, "get_order_dto"):
-            dto = self.view.get_order_dto()
+        if hasattr(self.view, "dto_from_form"):
+            dto = self.view.dto_from_form()
         self.service.create(dto)
-        if self.view and hasattr(self.view, "refresh"):
+        if hasattr(self.view, "refresh"):
             self.view.refresh(self.service.list_all())
 
     def check_contract(self):
-        """Check supplier contract for the current order."""
-        if self.contract_service:
-            self.contract_service.validate_contract(1)
-        if self.view and hasattr(self.view, "refresh"):
-            self.view.refresh(self.service.list_all())
+        """Validate selected supplier contract."""
+        if not self.contract_service or not self.view:
+            return None
+        cid = None
+        if hasattr(self.view, "get_selected_contract"):
+            cid = self.view.get_selected_contract()
+        return self.contract_service.verify(cid)

--- a/controllers/report_controller.py
+++ b/controllers/report_controller.py
@@ -5,19 +5,22 @@ class ReportController:
         self.view = view
 
     def generate_report(self):
-        """Generate a report using the configured service."""
-        if not self.report_service or not self.view:
+        """Fetch history and export to a chosen file."""
+        if not self.report_service or not self.history_service:
             return
-        rows = []
-        if hasattr(self.view, "get_rows"):
-            rows = self.view.get_rows()
-        out = self.report_service.export(rows, "report.out")
-        return out
+        rows = self.history_service.list_all()
+        if not rows:
+            return
+        from tkinter.filedialog import asksaveasfilename
+        path = asksaveasfilename()
+        if not path:
+            return
+        kind = "pdf" if path.lower().endswith(".pdf") else "csv"
+        return self.report_service.export(kind, rows, path)
 
     def show_supply_history(self):
-        """Display supply history using the history service."""
+        """Refresh the view with supply history."""
         if not self.history_service or not self.view:
             return
-        data = self.history_service.get_history()
-        if hasattr(self.view, "display_history"):
-            self.view.display_history(data)
+        if hasattr(self.view, "refresh"):
+            self.view.refresh(self.history_service.list_all())

--- a/controllers/supply_controller.py
+++ b/controllers/supply_controller.py
@@ -4,20 +4,18 @@ class SupplyController:
         self.view = view
 
     def register_supply(self):
-        """Register a new supply."""
+        """Register supply via service."""
         if not self.view or not self.service:
             return
-        # Expect view to provide get_supply() and get_records() helpers
-        if hasattr(self.view, "get_supply") and hasattr(self.view, "get_records"):
-            supply = self.view.get_supply()
-            records = self.view.get_records()
-            self.service.register_supply(supply, records)
+        dto = {}
+        if hasattr(self.view, "dto_from_form"):
+            dto = self.view.dto_from_form()
         else:
-            # Fallback: try to read minimal fields directly
             try:
-                supply = self.view.supply
-                records = self.view.records
-                self.service.register_supply(supply, records)
+                dto = {
+                    "supply": self.view.get_supply(),
+                    "records": self.view.get_records(),
+                }
             except AttributeError:
-                # Not enough information – ignore in stub implementation
-                pass
+                return
+        return self.service.register(dto)

--- a/services/contract_service.py
+++ b/services/contract_service.py
@@ -10,3 +10,6 @@ class ContractService:
         contract = self.contract_dao.find_by_id(contract_id)
         # Тут може бути додаткова логіка
         return contract is not None and contract.contact_info != ""
+
+    def verify(self, contract_id: int):
+        return self.validate_contract(contract_id)

--- a/services/history_service.py
+++ b/services/history_service.py
@@ -8,3 +8,6 @@ class HistoryService:
         """Return supply history records from DAO."""
         return self.history_dao.fetch_records(filters)
 
+    def list_all(self):
+        return self.get_history()
+

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -1,13 +1,12 @@
-from strategy.export_strategy import ExportStrategy
+from strategy.csv_export_strategy import CSVExportStrategy
+from strategy.pdf_export_strategy import PDFExportStrategy
 
 class ReportService:
-    def __init__(self):
-        self.strategy: ExportStrategy = None
-
-    def set_strategy(self, strategy: ExportStrategy):
-        self.strategy = strategy
-
-    def export(self, rows, out_path):
-        if not self.strategy:
-            raise Exception("Стратегія експорту не вибрана!")
-        return self.strategy.export(rows, out_path)
+    def export(self, kind: str, rows, out_path="report.out"):
+        if kind == "csv":
+            strategy = CSVExportStrategy()
+        elif kind == "pdf":
+            strategy = PDFExportStrategy()
+        else:
+            raise ValueError("Unsupported export type")
+        return strategy.export(rows, out_path)

--- a/services/supply_service.py
+++ b/services/supply_service.py
@@ -4,17 +4,22 @@ from models.supply import Supply
 from models.supply_record import SupplyRecord
 
 class SupplyService:
-    """Реєстрація поставок + Observer (оновлення складу)."""
+    """Реєстрація поставок з формуванням події."""
+
     def __init__(self, supply_dao: SupplyDAO, record_dao: SupplyRecordDAO):
         self.supply_dao = supply_dao
         self.record_dao = record_dao
 
+    def register(self, dto: dict) -> str:
+        supply: Supply = dto.get("supply")
+        records: list[SupplyRecord] = dto.get("records", [])
+        self.register_supply(supply, records)
+        return "<<SupplySaved>>"
+
     def register_supply(self, supply: Supply, records: list[SupplyRecord]) -> Supply:
         if not records:
             raise ValueError("Supply must contain at least one record")
-        # 1. Вставка поставки
         self.supply_dao.insert(supply)  # заповнює supply.id
-        # 2. Вставка позицій
         for rec in records:
             rec.supply_id = supply.id
             self.record_dao.insert(rec)  # Observer збільшить залишки

--- a/tests/service/test_report_service.py
+++ b/tests/service/test_report_service.py
@@ -2,14 +2,16 @@ import pytest
 from unittest.mock import MagicMock
 from services.report_service import ReportService
 
-def test_export_without_strategy_raises():
-    service = ReportService()
-    with pytest.raises(Exception):
-        service.export([], "out.csv")
 
-def test_export_with_strategy():
+def test_export_unknown_type():
     service = ReportService()
-    mock_strategy = MagicMock()
-    service.set_strategy(mock_strategy)
-    service.export([{"x": 1}], "out.csv")
-    mock_strategy.export.assert_called_once()
+    with pytest.raises(ValueError):
+        service.export("txt", [])
+
+
+def test_export_csv_uses_strategy(monkeypatch):
+    service = ReportService()
+    mock = MagicMock()
+    monkeypatch.setattr("services.report_service.CSVExportStrategy", lambda: mock)
+    service.export("csv", [{"x": 1}], "out.csv")
+    mock.export.assert_called_once()

--- a/tests/service/test_supply_service.py
+++ b/tests/service/test_supply_service.py
@@ -29,10 +29,11 @@ def test_register_supply_ok(service, supply_dao, record_dao):
         SupplyRecord(supply_id=None, component_id=2, quantity=5, price=50.0)
     ]
     supply_dao.insert.side_effect = lambda s: setattr(s, 'id', 1) or 1
-    service.register_supply(supply, records)
+    result = service.register({"supply": supply, "records": records})
     supply_dao.insert.assert_called_once_with(supply)
     assert all(r.supply_id == 1 for r in records)
     assert record_dao.insert.call_count == 2
+    assert result == "<<SupplySaved>>"
 
 def test_register_supply_empty_records(service):
     supply = Supply(
@@ -42,4 +43,4 @@ def test_register_supply_empty_records(service):
         storekeeper_id=1
     )
     with pytest.raises(ValueError):
-        service.register_supply(supply, [])
+        service.register({"supply": supply, "records": []})


### PR DESCRIPTION
## Summary
- update `OrderController` to get DTO from the view and verify contracts
- rework `SupplyController` and `SupplyService` to use DTO and emit event message
- refactor `ReportService` to pick export strategy by file type
- extend `ReportController` to fetch history and export reports
- expose `HistoryService.list_all` and `ContractService.verify`
- adjust tests for new service interfaces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f6793ac88328bd1dacbbc02d7e77