### PR TITLE
Implement basic DAO stubs

### DIFF
--- a/dao/contract_dao.py
+++ b/dao/contract_dao.py
@@ -1,4 +1,6 @@
 class ContractDAO:
-    """DAO для контрактів (заглушка)."""
     def find_by_id(self, contract_id):
         return None
+
+    def verify(self, contract_id):
+        return False

--- a/dao/history_dao.py
+++ b/dao/history_dao.py
@@ -1,4 +1,6 @@
 class HistoryDAO:
-    """DAO для історії (заглушка)."""
-    def fetch_records(self, filters=None):
+    def select_all(self):
         return []
+
+    def fetch_records(self, filters=None):
+        return self.select_all()

--- a/dao/order_dao.py
+++ b/dao/order_dao.py
@@ -1,0 +1,36 @@
+import sqlite3
+import json
+
+class OrderDAO:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+        self._ensure_table()
+
+    def _ensure_table(self):
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS orders (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                data TEXT
+            )
+            """
+        )
+        self.conn.commit()
+
+    def insert(self, dto: dict) -> int:
+        cur = self.conn.execute(
+            "INSERT INTO orders (data) VALUES (?)",
+            (json.dumps(dto),),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
+    def select_all(self) -> list[dict]:
+        cur = self.conn.execute("SELECT id, data FROM orders ORDER BY id")
+        rows = cur.fetchall()
+        result = []
+        for row in rows:
+            data = json.loads(row["data"] if isinstance(row, sqlite3.Row) else row[1])
+            data["id"] = row["id"] if isinstance(row, sqlite3.Row) else row[0]
+            result.append(data)
+        return result


### PR DESCRIPTION
## Summary
- implement OrderDAO with SQLite storage
- add `verify` to ContractDAO
- add `select_all` to HistoryDAO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f553c43c8328acb54f184fdcb5e1