### PR TITLE
Update component DAO interface

### DIFF
--- a/dao/component_dao.py
+++ b/dao/component_dao.py
@@ -22,7 +22,10 @@ class ComponentDAO:
         self.conn.commit()
 
     # CRUD --------------------------------------------------
-    def insert(self, comp: Component) -> int:
+    def insert(self, dto):
+        pass
+
+    def insert_component(self, comp: Component) -> int:
         with self.conn:
             cur = self.conn.execute(
                 "INSERT INTO components (name, unit, quantity_in_stock) VALUES (?, ?, ?)",
@@ -31,7 +34,10 @@ class ComponentDAO:
             comp.id = cur.lastrowid
         return comp.id
 
-    def select_all(self) -> list[Component]:
+    def select_all(self):
+        pass
+
+    def select_all_components(self) -> list[Component]:
         cur = self.conn.execute("SELECT id, name, unit, quantity_in_stock FROM components ORDER BY id")
         rows = cur.fetchall()
         return [
@@ -39,7 +45,7 @@ class ComponentDAO:
             for row in rows
         ]
 
-    def find_by_id(self, comp_id: int) -> Component | None:
+    def select_by_id(self, comp_id: int) -> Component | None:
         cur = self.conn.execute(
             "SELECT id, name, unit, quantity_in_stock FROM components WHERE id = ?",
             (comp_id,),
@@ -50,11 +56,14 @@ class ComponentDAO:
         return Component(id=row[0], name=row[1], unit=row[2], quantity_in_stock=row[3])
 
     # Alias for backwards compatibility with tests
-    def select_by_id(self, comp_id: int) -> Component | None:
-        """Return component by ID (same as :meth:`find_by_id`)."""
-        return self.find_by_id(comp_id)
+    def find_by_id(self, comp_id: int) -> Component | None:
+        """Return component by ID (same as :meth:`select_by_id`)."""
+        return self.select_by_id(comp_id)
 
-    def update(self, comp: Component) -> bool:
+    def update(self, id, dto):
+        pass
+
+    def update_component(self, comp: Component) -> bool:
         with self.conn:
             cur = self.conn.execute(
                 "UPDATE components SET name = ?, unit = ?, quantity_in_stock = ? WHERE id = ?",

--- a/services/component_service.py
+++ b/services/component_service.py
@@ -10,10 +10,10 @@ class ComponentService:
     def create(self, comp: Component) -> int:
         if not comp.validate():
             raise ValueError("Invalid component data")
-        return self.dao.insert(comp)
+        return self.dao.insert_component(comp)
 
     def list_all(self) -> list[Component]:
-        return self.dao.select_all()
+        return self.dao.select_all_components()
 
     def get_by_id(self, comp_id: int) -> Component:
         comp = self.dao.find_by_id(comp_id)
@@ -24,7 +24,7 @@ class ComponentService:
     def update(self, comp: Component) -> bool:
         if not comp.validate():
             raise ValueError("Invalid component data")
-        return self.dao.update(comp)
+        return self.dao.update_component(comp)
 
     def delete(self, comp_id: int) -> bool:
         return self.dao.delete(comp_id)

--- a/tests/dao/test_component_dao.py
+++ b/tests/dao/test_component_dao.py
@@ -21,13 +21,13 @@ def sample_component():
     return {"name": "Bolt", "unit": "pcs", "quantity_in_stock": 10}
 
 def test_insert_and_select(component_dao, sample_component):
-    cid = component_dao.insert(Component(**sample_component))
+    cid = component_dao.insert_component(Component(**sample_component))
     stored = component_dao.select_by_id(cid)
     assert stored.name == sample_component["name"]
 
 def test_update_quantity(dao):
     comp = Component(name='Nut', unit='pcs', quantity_in_stock=5)
-    comp_id = dao.insert(comp)
+    comp_id = dao.insert_component(comp)
     dao.update_quantity(comp_id, 3)
     updated = dao.find_by_id(comp_id)
     assert updated.quantity_in_stock == 8


### PR DESCRIPTION
## Summary
- add DTO-based stub methods in `ComponentDAO`
- rename `find_by_id` implementation to `select_by_id`
- update service and tests for new DAO API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f547ac7483288e07149852019046